### PR TITLE
Fix deprecated supported_features() for compatibility with HA 2025.1

### DIFF
--- a/custom_components/litetouch/light.py
+++ b/custom_components/litetouch/light.py
@@ -1,7 +1,7 @@
 """Support for LiteTouch lights."""
 import logging
 
-from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, LightEntity
+from homeassistant.components.light import ATTR_BRIGHTNESS, LightEntity, COLOR_MODE_BRIGHTNESS
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -55,9 +55,14 @@ class LiteTouchLight(LiteTouchDevice, LightEntity):
         self._controller.get_led_states(self._addr)
 
     @property
-    def supported_features(self):
-        """Supported features."""
-        return SUPPORT_BRIGHTNESS
+    def color_mode(self):
+        """Return the color mode of the light."""
+        return COLOR_MODE_BRIGHTNESS
+
+    @property
+    def supported_color_modes(self):
+        """Flag supported color modes."""
+        return {COLOR_MODE_BRIGHTNESS}
 
     def turn_on(self, **kwargs):
         """Turn on the light."""


### PR DESCRIPTION
In HA 2025.1, the supported_features() method was deprecated for specifying light attributes.  This causes a break in the light integration when updating to 2025.1

Properties color_mode() and supported_color_modes() have been added to replace the deprecated feature